### PR TITLE
Create external network on dev environment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@ SHELL := /bin/bash
 
 prepare-dev-env:
 	cp env-file-for-local.dev .env
+	docker network create services_default
 
 
 # docker compose TASKS


### PR DESCRIPTION
I just noticed that the external network `services_default` is not created when performing make actions. I added a small fix by creating the network in `make prepare-dev-env`. It might be not the best place, so feel free to fix it as you think it's better to :)